### PR TITLE
fix(pipeline): properly convert buffer into a string

### DIFF
--- a/Code/system/pipeline.cpp
+++ b/Code/system/pipeline.cpp
@@ -197,26 +197,24 @@ crosschain_proto::CrossChainMessage Pipeline::DataRecv(uint16_t node_id)
     // So, we use the two available bit masks.
     rv = nng_recv(sock, &buffer, &sz, NNG_FLAG_ALLOC | NNG_FLAG_NONBLOCK);
 
-    crosschain_proto::CrossChainMessage buf;
-
     // nng_recv is non-blocking, if there is no data, return value is non-zero.
     if (rv != 0)
     {
-        // cout << "One" << endl;
-        buf.set_sequence_id(0);
-        buf.set_ack_id(0);
-        buf.set_transactions("hello");
-    }
-    else
-    {
-        std::string str_buf(buffer, sz);
-        cout << "Two: " << sz << " :: " << str_buf << endl;
-        bool flag = buf.ParseFromString(str_buf);
-        cout << "Recvd: " << buf.sequence_id() << endl;
+        cout << "ERROR nng_recv has error value = " << rv << std::endl;
+
+        crosschain_proto::CrossChainMessage fakeMsg;
+        fakeMsg.set_transactions("ERROR=" + std::to_string(rv));
+        return fakeMsg;
     }
 
-    // nng_free(msg->buf, msg->data_len);
-    return buf;
+    crosschain_proto::CrossChainMessage receivedMsg;
+    const std::string str_buf{buffer, sz};
+    nng_free(buffer, sz);
+    cout << "Two: " << sz << " :: " << str_buf << endl;
+    receivedMsg.ParseFromString(str_buf);
+    cout << "Recvd: " << receivedMsg.sequence_id() << endl;
+
+    return receivedMsg;
 }
 
 /* This function is used to send message to a specific node in other RSM.


### PR DESCRIPTION
Why is this change being made?
-------------------------------------
For a `std::string` of length `N`, the c-string equivalent has `N+1` bytes
because it must end with a null terminator '\0'.

Our usage of NNG sent the first `N` bytes of a string of length `N` meaning
our data received by other nodes did not contain a null terminator
meaning they are not c-strings. This is not inherently wrong, but the
receiving nodes treated the received data as a c-string and constructed
a `std::string` from it. This leads to undefined behavior (the string will likely copy all byte
until the byte `0x00` appears in memory) which likely was the source of the prior bug.

Also we had a memory leak because nothing would deallocate buffers nng allocated for us.

What has changed?
-------------------------------------
Now we treat the data received from NNG as packed bytes of length N and
use that to initialize the std::string. This then prevents the prior
undefined behavior and the bug that came along with it.

And we deallocate buffers allocated by nng.