### PR TITLE
feat(make): Add Address and UndefinedBehavior sanitizers

### DIFF
--- a/Code/Makefile
+++ b/Code/Makefile
@@ -2,6 +2,7 @@ CC=g++
 CFLAGS=-Wall -g -std=c++17
 NNMSG=${PWD}/deps/nng
 BOOST=${PWD}/deps/boost_1_80_0
+SANITIZERS=-fsanitize=address -fsanitize=undefined
 
 .SUFFIXES: .o .cpp .h
 
@@ -10,9 +11,11 @@ DEPS = -I$(NNMSG)/include -I$(BOOST)
 
 PROTO_DIR = ./system/protobuf/
 
-CFLAGS += $(DEPS) 
+CFLAGS += $(DEPS)
+CFLAGS += $(SANITIZERS)
 LDFLAGS = -L$(NNMSG)/lib 
 LDFLAGS += $(CFLAGS)
+LDFLAGS += $(SANITIZERS)
 LIBS = -lnng -lanl -ldl -lprotobuf -lpthread
 
 SOURCES = $(wildcard ./system/*.cpp ./system/*.cc)


### PR DESCRIPTION
Why is this change being made?
-------------------------------------------
C++ is unsafe and we need ways to know if were introducing bugs. Sanitizers are lightweight additions which can catch bad behavior at runtime.

What has changed?
-------------------------------------------
Our library will now compile and run with address and undefined behavior sanitizers. The bug which previously lost us a ton of time now can be caught automatically during runtime. I took away the string size check on line 204 of the pipeline class, and normally where we would crash, the sanitizer catches the potential error, and outputs which function caused it `#3 0x5596a2cdd1f1 in Pipeline::DataRecv(unsigned short) system/pipeline.cpp:204`. Image below

<img width="795" alt="image" src="https://user-images.githubusercontent.com/26232211/199828935-58c49e29-75c9-4ee7-aa74-24177ab21caa.png">
