### PR TITLE
feat(infra): Add Boost Test for unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Code/*/*.o
 Code/nng-1.5.2/*
 Code/protobuf-*
 Code/scrooge
+Code/check
 Docs/*.pdf
 Docs/*.aux
 Docs/*.log

--- a/Code/Makefile
+++ b/Code/Makefile
@@ -20,14 +20,20 @@ LIBS = -lnng -lanl -ldl -lprotobuf -lpthread
 
 SOURCES = $(wildcard ./system/*.cpp ./system/*.cc)
 SOURCES += $(wildcard ./configuration/*.cpp)
+LIBRARY_SOURCES = $(filter-out ./system/main.cpp, $(SOURCES))
+TEST_SOURCES = $(wildcard ./test/*.cpp ./test/*.cc)
+
 SOURCES_OBJ = $(SOURCES:.cpp=.o)
+LIBRARY_SOURCES_OBJ = $(LIBRARY_SOURCES:.cpp=.o)
+TEST_SOURCES_OBJ = $(TEST_SOURCES:.cpp=.o)
+
 FORMAT_TARGET_REGEX = '.*\.\(cpp\|c\|h\|.proto\)'
 
 #abc:
 #	echo ${SOURCES}
 #	echo ${SOURCES_OBJ}
 
-.PHONY: all clean format
+.PHONY: all clean format test
 all: scrooge
 
 scrooge : $(SOURCES_OBJ)
@@ -44,8 +50,14 @@ scrooge : $(SOURCES_OBJ)
 
 
 clean:
-	rm -f system/*.o configuration/*.o scrooge
+	rm -f system/*.o configuration/*.o scrooge test/*.o check
 
 format:
 	find system -regex $(FORMAT_TARGET_REGEX) -exec clang-format -i -style=Microsoft {} \;
 	find configuration -regex $(FORMAT_TARGET_REGEX) -exec clang-format -i -style=Microsoft {} \;
+
+check : $(LIBRARY_SOURCES_OBJ) $(TEST_SOURCES_OBJ)
+	$(CC) -o $@ $^ -I$(SRC_DIRS) $(LDFLAGS) $(LIBS)
+	./check -l message
+%.o : %.cpp
+	$(CC) -c ${CFLAGS} -I$(SRC_DIRS)  -o $@ $<

--- a/Code/test/main.cpp
+++ b/Code/test/main.cpp
@@ -1,0 +1,2 @@
+#define BOOST_TEST_MODULE "C++ Unit Tests for BFT_RSM"
+#include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
What has changed?
--------------------------
The test directory has been added with a makefile rule (make check) to
generate a binary which will run all boost unit tests in the test
directory. This is compiled against the library allowing us to test code
changes.

How to use
--------------------------
1. Create a new file Code/test/<SourceFile>Test.cpp
2. Make the previous file contain `include <boost/test/unit_test.hpp>`
3. Init the new test suite with
`BOOST_AUTO_TEST_SUITE(<SourceFile>_test)`
4. Add a new test with `BOOST_AUTO_TEST_CASE(test_name) { ... }`
    a. Inside the ... put any testing logic to compute an answer
    b. Test the result with `BOOST_CHECK(test_var == expected_var)`
    c. Make debug logs with `BOOST_TEST_MESSAGE("string")`
5. Repeat step 4 to make all tests desired
6. check if its working by running `boost check` or `./check -l message`